### PR TITLE
Add support for depot.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ steps:
 
 | Elastic Stack | Agent Stack K8s | Hosted (Mac) | Hosted (Linux) | Notes |
 | :-----------: | :-------------: | :----: | :----: |:---- |
-| ✅ |  ⚠️ | ❌ | ⚠️ | **All** – Requires `awscli` or `gcloud` for ECR and GAR (Google Artifact Store) respectively<br/>**Hosted (Mac)** - Docker engine not available |
+| ✅ |  ⚠️ | ❌ (except Depot) | ⚠️ | **All** – Requires `awscli`, `gcloud`, `depot` for ECR, GAR (Google Artifact Store) and Depot respectively<br/>**Hosted (Mac)** - Docker engine not available – not needed for Depot as builds run on depot.dev runners |
 
 - ✅ Fully supported (all combinations of attributes have been tested to pass)
 - ⚠️ Partially supported (some combinations cause errors/issues)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are all the options available to configure this plugin's behaviour.
 
 #### `provider` (string)
 
-The registry provider to use. Supported values: `ecr`, `gar`.
+The registry provider to use. Supported values: `ecr`, `gar`, `depot`.
 
 #### `image` (string)
 
@@ -57,6 +57,23 @@ The GAR region (e.g., `us-east1`) or a full GAR hostname (e.g., `europe-west10-d
 #### `repository` (string)
 
 The name of the Artifact Registry repository. If omitted, it defaults to the image name.
+
+
+### Depot Provider Options
+
+**Note:** Authentication, container build and push is handled by the `depot` CLI. Ensure your Buildkite agent has authenticated with depot.dev before running this plugin (e.g., using a service account key or Workload Identity Federation).
+
+#### `project-id` (string)
+
+The depot.dev project ID.
+
+#### `access-token` (string)
+
+The depot.dev access token, required when not using OIDC.
+
+#### `oidc` (boolean, default: `false`)
+
+Enable OIDC authentication.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,57 @@ steps:
             repository: my-docker-repo
 ```
 
+### Push to depot.dev
+
+#### Using OIDC Authentication (Recommended), see [Depot.dev documentation](https://depot.dev/docs/cli/authentication#adding-a-trust-relationship-for-buildkite)
+
+```yaml
+steps:
+  - label: ":docker: Build and Push"
+    plugins:
+      - docker-image-push#v1.0.1:
+          provider: depot
+          image: my-app
+          tag: "v1.2.3"
+          depot:
+            project-id: "$$DEPOT_DEV_PROJECT_ID"
+            oidc: true
+```
+
+#### Using Access Token Authentication
+
+```yaml
+steps:
+  - label: ":docker: Build and Push"
+    plugins:
+      - docker-image-push#v1.0.1:
+          provider: depot
+          image: my-app
+          tag: "v1.2.3"
+          depot:
+            access-token: "$$DEPOT_DEV_TOKEN"
+            project-id: "$$DEPOT_DEV_PROJECT_ID"
+```
+
+##### With fetching secrets from Buildkite secrets
+
+```yaml
+steps:
+  - label: ":docker: Build and Push"
+    plugins:
+      - secrets#v1.0.0:
+          variables:
+            DEPOT_DEV_PROJECT_ID: DEPOT_DEV_PROJECT_ID
+            DEPOT_DEV_TOKEN: DEPOT_DEV_TOKEN
+      - docker-image-push#v1.0.1:
+          provider: depot
+          image: my-app
+          tag: "v1.2.3"
+          depot:
+            access-token: "$$DEPOT_DEV_TOKEN"
+            project-id: "$$DEPOT_DEV_PROJECT_ID"
+```
+
 ### Verbose Mode
 
 Enable verbose mode for detailed debug output.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ The depot.dev access token, required when not using OIDC.
 
 Enable OIDC authentication.
 
+#### `context` (string, default: `.`)
+
+The build context path (defaults to current directory).
+
+#### `platform` (string)
+
+The target platform for the build (e.g., `linux/amd64`, `linux/arm64`).
+
 ## Examples
 
 ### Push to Amazon ECR

--- a/hooks/environment
+++ b/hooks/environment
@@ -32,11 +32,11 @@ main() {
   log_info "Image - $image"
 
   case "$provider" in
-    ecr|gar)
+    ecr|gar|depot)
       ;;
     *)
       log_error "unsupported provider '$provider'"
-      log_info "Supported providers: ecr, gar"
+      log_info "Supported providers: ecr, gar, depot"
       exit 1
       ;;
   esac

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -13,7 +13,6 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/plugin.bash"
 
 main() {
   echo "--- :docker: Pushing Docker image"
-  log_info "Pushing Docker image"
 
   # Ensure required CLIs are available
   check_dependencies
@@ -31,14 +30,26 @@ main() {
   setup_provider_environment "$provider"
 
   local full_image="${image}:${tag}"
-  log_info "Pushing ${full_image}"
 
-  if push_image "${full_image}"; then
-    log_success "Image pushed successfully: ${full_image}"
-  else
-    log_error "Failed to push image"
-    exit 1
-  fi
+  case "$provider" in
+    depot)
+      if build_and_push_depot_image "${full_image}"; then
+        log_success "Image built and pushed successfully: ${full_image}"
+      else
+        log_error "Failed to build and push image using Depot"
+        exit 1
+      fi
+      ;;
+    *)
+      # Use standard docker push for other providers
+      if push_image "${full_image}"; then
+        log_success "Image pushed successfully: ${full_image}"
+      else
+        log_error "Failed to push image"
+        exit 1
+      fi
+      ;;
+  esac
 }
 
 main "$@"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -9,6 +9,8 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/shared.bash"
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/ecr.bash"
 # shellcheck source=lib/providers/gar.bash
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/gar.bash"
+# shellcheck source=lib/providers/depot.bash
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/providers/depot.bash"
 
 setup_provider_environment() {
   local provider="$1"
@@ -19,6 +21,9 @@ setup_provider_environment() {
       ;;
     gar)
       setup_gar_environment
+      ;;
+    depot)
+      setup_depot_environment
       ;;
 
     *)

--- a/lib/providers/depot.bash
+++ b/lib/providers/depot.bash
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# depot.dev provider for Docker push plugin
+
+setup_depot_environment() {
+  # Read raw config values
+  local access_token_raw="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_ACCESS_TOKEN:-}"
+  local project_id_raw="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_PROJECT_ID:-}"
+  local use_oidc="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_OIDC:-false}"
+  
+  local project_id
+  # Restrict environment variable expansion to safe, allow listed variables only
+  # shellcheck disable=SC2016
+  case "${project_id_raw}" in
+    '$DEPOT_PROJECT_ID'|'$DEPOT_DEV_PROJECT_ID'|'$BUILDKITE_PLUGIN_'*)
+      local var_name="${project_id_raw#$}"
+      project_id="${!var_name}"
+      ;;
+    *)
+      project_id="${project_id_raw}"
+      ;;
+  esac
+  
+  project_id="${project_id:-${DEPOT_DEV_PROJECT_ID:-}}"
+
+  if [[ -z "$project_id" ]]; then
+    log_error "depot project-id is required"
+    exit 1
+  fi
+
+  log_info "Setting up Depot build environment"
+
+  if [[ "${use_oidc}" == "true" ]]; then
+    # For OIDC, we don't export DEPOT_TOKEN - depot CLI will handle OIDC flow automatically
+    # The Depot CLI will detect the Buildkite environment and retrieve OIDC tokens as needed
+    export DEPOT_PROJECT_ID="${project_id}"
+    log_info "Depot CLI will use OIDC authentication automatically"
+  else
+    local access_token
+    # Restrict environment variable expansion to safe, allow listed variables only
+    # shellcheck disable=SC2016
+    case "${access_token_raw}" in
+      '$DEPOT_TOKEN'|'$DEPOT_DEV_TOKEN'|'$BUILDKITE_PLUGIN_'*)
+        local var_name="${access_token_raw#$}"
+        access_token="${!var_name}"
+        ;;
+      *)
+        access_token="${access_token_raw}"
+        ;;
+    esac
+    
+    access_token="${access_token:-${DEPOT_DEV_TOKEN:-}}"
+
+    if [[ -z "$access_token" ]]; then
+      log_error "depot access-token is required when not using OIDC"
+      log_error "Either provide access-token or set oidc: true"
+      exit 1
+    fi
+
+    log_info "Using token-based authentication with Depot"
+    export DEPOT_TOKEN="${access_token}"
+    export DEPOT_PROJECT_ID="${project_id}"
+  fi
+}
+
+build_and_push_depot_image() {
+  local image_name="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_IMAGE:-}"
+  local tag="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_TAG:-latest}"
+  local project_id="${DEPOT_PROJECT_ID:-}"
+  local context="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_CONTEXT:-.}"
+
+  if [[ -z "${image_name}" ]]; then
+    log_error "Image name is required for depot build."
+    exit 1
+  fi
+
+  if [[ -z "${project_id}" ]]; then
+    log_error "Project ID is required for depot build."
+    exit 1
+  fi
+
+  # Build and save image using depot build --save
+  local build_args=()
+  build_args+=("--save")
+  build_args+=("--save-tag=${tag}")
+  build_args+=("--project=${project_id}")
+  
+  
+  # Add platform if specified
+  local platform="${BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_PLATFORM:-}"
+  if [[ -n "${platform}" ]]; then
+    build_args+=("--platform=${platform}")
+  fi
+  
+  local full_image="${image_name}:${tag}"
+  build_args+=("--tag=${full_image}")
+  
+  # Validate build context
+  if [[ ! -d "${context}" ]]; then
+    log_error "Build context '${context}' does not exist or is not a directory"
+    log_error "Current working directory: $(pwd)"
+    log_error "Available directories: $(ls -la 2>/dev/null || echo 'none')"
+    return 1
+  fi
+  
+  log_info "Building and pushing image: ${full_image} from context: ${context}"
+  log_info "Depot build command: depot build ${build_args[*]} -- ${context}"
+  
+  if depot build "${build_args[@]}" -- "${context}"; then
+    return 0
+  else
+    log_error "Failed to build image"
+    return 1
+  fi
+}

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -47,6 +47,11 @@ check_dependencies() {
         missing_deps+=("gcloud")
       fi
       ;;
+    depot)
+      if ! command_exists depot; then
+        missing_deps+=("depot")
+      fi
+      ;;
   esac
 
   if [[ ${#missing_deps[@]} -gt 0 ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: Docker Image Push
-description: Push Docker images to ECR (AWS) or GAR (Google Artifact Registry)
+description: Push Docker images to ECR (AWS), GAR (Google Artifact Registry), or depot.dev
 author: https://github.com/buildkite-plugins
 requirements:
   - bash
@@ -8,7 +8,7 @@ configuration:
   properties:
     provider:
       type: string
-      enum: [ecr, gar]
+      enum: [ecr, gar, depot]
       description: Registry provider type
     image:
       type: string
@@ -45,6 +45,28 @@ configuration:
         repository:
           type: string
           description: Artifact Registry repository name (defaults to the image name when omitted)
+      additionalProperties: false
+    depot:
+      type: object
+      description: depot.dev-specific configuration
+      properties:
+        access-token:
+          type: string
+          description: depot.dev access token (not required when using OIDC)
+        project-id:
+          type: string
+          description: depot.dev project ID
+        oidc:
+          type: boolean
+          description: Use OIDC authentication instead of access token
+          default: false
+        context:
+          type: string
+          description: Build context path (defaults to current directory)
+          default: "."
+        platform:
+          type: string
+          description: Target platform for the build (e.g., linux/amd64, linux/arm64)
       additionalProperties: false
     verbose:
       type: boolean

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -39,6 +39,24 @@ setup() {
   assert_output --partial 'Google Cloud SDK is required'
 }
 
+@test "Depot provider requires access token when not using OIDC" {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_PROVIDER='depot'
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_IMAGE='test-image'
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_PROJECT_ID='test-project'
+  run "$PWD"/hooks/environment
+  assert_failure
+  assert_output --partial 'depot access-token is required when not using OIDC'
+}
+
+@test "Depot provider requires project ID" {
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_PROVIDER='depot'
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_IMAGE='test-image'
+  export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_DEPOT_ACCESS_TOKEN='test-token'
+  run "$PWD"/hooks/environment
+  assert_failure
+  assert_output --partial 'depot project-id is required'
+}
+
 @test "Fails on unsupported provider" {
   export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_PROVIDER='unknown'
   export BUILDKITE_PLUGIN_DOCKER_IMAGE_PUSH_IMAGE='test-image'


### PR DESCRIPTION
Add support for building and pushing images to [depot.dev](https://depot.dev).

Includes:
* [OIDC auth](https://depot.dev/docs/cli/authentication#adding-a-trust-relationship-for-buildkite)
* Token-based auth ([user token](https://depot.dev/docs/cli/authentication#user-access-tokens) or [project token](https://depot.dev/docs/cli/authentication#project-tokens))
* Build and push images with Depot CLI